### PR TITLE
skip omegaconf to avoid stack overflow due to recursive calls

### DIFF
--- a/src/onediff/infer_compiler/transform/manager.py
+++ b/src/onediff/infer_compiler/transform/manager.py
@@ -86,6 +86,8 @@ class TransformManager:
         self.logger.debug(debug_message)
 
     def _transform_entity(self, entity):
+        if "omegaconf" in str(entity):
+            return entity
         result = self.mocker.mock_entity(entity)
         if result is None:
             RuntimeError(f"Failed to transform entity: {entity}")


### PR DESCRIPTION
skip omegaconf to avoid stack overflow due to recursive calls when calling oneflow_compile in stability-difussion-webui