### PR TITLE
add sd-webui performance data; fix refiner model bug

### DIFF
--- a/onediff_sd_webui_extensions/README.md
+++ b/onediff_sd_webui_extensions/README.md
@@ -1,6 +1,6 @@
 # Stable-Diffusion-WebUI-OneDiff
 
-- Performance of Community Edition
+- [Performance of Community Edition](#performance-of-community-edition)
 - [Installation Guide](#installation-guide)
 - [Extensions Usage](#extensions-usage)
 
@@ -8,8 +8,9 @@
 
 Updated on DEC 13, 2023. Device: RTX 3090. Resolution: 1024x1024
 
-torch(Baseline) | onediff(Optimized) | Percentage improvement
-2.97it/s | 4.45it/s | 50%
+| torch(Baseline) | onediff(Optimized) | Percentage improvement |
+| --------------- | ------------------ | ---------------------- |
+| 2.99it/s        | 4.49it/s           | 50%                    |
 
 ## Installation Guide
 

--- a/onediff_sd_webui_extensions/README.md
+++ b/onediff_sd_webui_extensions/README.md
@@ -10,7 +10,7 @@ Updated on DEC 13, 2023. Device: RTX 3090. Resolution: 1024x1024
 
 | torch(Baseline) | onediff(Optimized) | Percentage improvement |
 | --------------- | ------------------ | ---------------------- |
-| 2.99it/s        | 4.49it/s           | 50%                    |
+| 2.99it/s        | 4.49it/s           | 50.17%                 |
 
 ## Installation Guide
 

--- a/onediff_sd_webui_extensions/README.md
+++ b/onediff_sd_webui_extensions/README.md
@@ -1,7 +1,15 @@
 # Stable-Diffusion-WebUI-OneDiff
 
+- Performance of Community Edition
 - [Installation Guide](#installation-guide)
 - [Extensions Usage](#extensions-usage)
+
+## Performance of Community Edition
+
+Updated on DEC 13, 2023. Device: RTX 3090. Resolution: 1024x1024
+
+torch(Baseline) | onediff(Optimized) | Percentage improvement
+2.97it/s | 4.45it/s | 50%
 
 ## Installation Guide
 

--- a/onediff_sd_webui_extensions/scripts/onediff.py
+++ b/onediff_sd_webui_extensions/scripts/onediff.py
@@ -174,11 +174,9 @@ def compile(sd_model):
     time_embed_wrapper = TimeEmbedModule(_compiled._deployable_module_model.oneflow_module.time_embed)
     # https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/openaimodel.py#L984
     setattr(_compiled._deployable_module_model.oneflow_module, "time_embed", time_embed_wrapper)
-    # for refiner model
-    shared.sd_model.model.diffusion_model = _compiled
 
 
-class Script(scripts.Script):  
+class Script(scripts.Script):
     def title(self):
         return "onediff_diffusion_model"
 


### PR DESCRIPTION
* 增加 sd-webui 性能数据
* 修复刚启动时设置 compiled model 的问题。这本是为 refiner model 引入的逻辑，但是刚启动时不应该这么设置，否则会影响 torch 的推理。可以判断 `_compiled` 不为 None 时设置。但是引入 refiner model 每次都会重新编译两个模型，所以暂时删除这个逻辑。