### PR TITLE
add oss model url

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,7 +16,7 @@ Download models from [here](#About-the-models). If you have downloaded the model
 Start docker container and run the benchmark by the following command.
 
 ```bash
-export BENCHMARK_MODEL_PATH=./benchmark_model
+export BENCHMARK_MODEL_PATH=`pwd`/onediff_benchmark_model
 docker compose -f ./docker-compose.onediff:benchmark-community-default.yaml up
 ```
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,7 +52,9 @@ benchmark_model
 You can obtain the models from [HuggingFace](https://huggingface.co) (excluding the int8 model) or download them in a zip file from our server:
 
 ```bash
-wget https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff_benchmark_model.zip -O onediff_benchmark_model.zip && unzip ./onediff_benchmark_model.zip -d .
+wget https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff_benchmark_model.zip \
+  -O onediff_benchmark_model.zip && \
+  unzip ./onediff_benchmark_model.zip -d .
 ```
 
 and **set the BENCHMARK_MODEL_PATH**:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -55,7 +55,7 @@ You can obtain the models from [HuggingFace](https://huggingface.co) (excluding 
 wget https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff_benchmark_model.zip -O onediff_benchmark_model.zip && unzip ./onediff_benchmark_model.zip -d .
 ```
 
-and **set the BENCHMARK_MODEL_PATH to the model path**:
+and **set the BENCHMARK_MODEL_PATH**:
 
 ```bash
 export BENCHMARK_MODEL_PATH=`pwd`/onediff_benchmark_model

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -49,21 +49,16 @@ benchmark_model
 ├── stable-diffusion-xl-base-1.0-int8
 ```
 
-You can obtain the models from [HuggingFace](https://huggingface.co) (excluding the int8 model) or download them from OSS (including the int8 model). The OSS download method is as follows:
+You can obtain the models from [HuggingFace](https://huggingface.co) (excluding the int8 model) or download them in a zip file from our server:
 
-- Obtain ossutil by executing the following command:
+```bash
+wget https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff_benchmark_model.zip -O onediff_benchmark_model.zip && unzip ./onediff_benchmark_model.zip -d .
+```
 
-  ```bash
-  wget http://gosspublic.alicdn.com/ossutil/1.7.3/ossutil64  && chmod u+x ossutil64
-  ```
+and **set the BENCHMARK_MODEL_PATH to the model path**:
 
-- Configure ossutil by referring to [the official example](https://www.alibabacloud.com/help/en/oss/developer-reference/configure-ossutil?spm=a2c63.p38356.0.0.337f374a4pcwa4)
-  ```bash
-  ossutil64 config
-  ```
+```bash
+export BENCHMARK_MODEL_PATH=`pwd`/onediff_benchmark_model
+```
 
-- Download the benchmark models finally
 
-  ```bash
-  ./ossutil64 cp -r oss://oneflow-pro/onediff_benchmark_model/  benchmark_model  --update 
-  ```

--- a/benchmarks/docker/config/community-default.yaml
+++ b/benchmarks/docker/config/community-default.yaml
@@ -4,7 +4,7 @@ oneflow_pip_index: "https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/commu
 repos:
   - onediff:
       repo_url: https://github.com/Oneflow-Inc/onediff.git
-      branch: dev_update_benchmark_scripts
+      branch: main
       cmds:
         - "python3 -m pip install transformers==4.27.1 diffusers[torch]==0.19.3"
         - "python3 -m pip install -e ."

--- a/benchmarks/docker/main.py
+++ b/benchmarks/docker/main.py
@@ -58,7 +58,7 @@ def parse_args():
         "-q",
         "--quiet",
         action="store_true",
-        help="the path to build context",
+        help="quiet mode",
     )
     args = parser.parse_args()
     return args


### PR DESCRIPTION
模型下载，由 ossutil （需要登录，不方便），改成 zip 下载所有，直接解压使用。
